### PR TITLE
Adding build-from-binary compatibility

### DIFF
--- a/specs/opencast4.spec
+++ b/specs/opencast4.spec
@@ -4,6 +4,7 @@
 %define __requires_exclude_from ^.*\\.jar$
 %define __provides_exclude_from ^.*\\.jar$
 
+%define ocversion 4
 %define srcversion 4.4
 %define uid   opencast
 %define gid   opencast
@@ -14,7 +15,7 @@
 %define ocdist allinone
 %endif
 
-Name:          opencast4-%{ocdist}
+Name:          opencast%{ocversion}-%{ocdist}
 Version:       %{srcversion}
 Release:       1%{?dist}
 Summary:       Open Source Lecture Capture & Video Management Tool

--- a/specs/opencast4.spec
+++ b/specs/opencast4.spec
@@ -78,10 +78,16 @@ educational videos.
 
 
 %prep
-%setup -q -c -a 0 -a 1
+%define fromsource %( if [ -d opencast%{ocversion}-%{ocdist}-%{srcversion}/opencast-%{srcversion}/build ]; then echo "1"; else echo "0"; fi )
 
+%if %fromsource
+%setup -q -c -a 0 -a 1
+%else
+%setup -c -D -T
+%endif
 
 %build
+%if %fromsource
 # Maven configuration
 cp %{SOURCE3} settings.xml
 sed -i "s#BUILDPATH#$(pwd)#" settings.xml
@@ -89,6 +95,9 @@ sed -i "s#BUILDPATH#$(pwd)#" settings.xml
 # Build Opencast
 cd opencast-%{srcversion}
 mvn -o -s ../settings.xml clean install
+%else
+cd opencast-%{srcversion}
+%endif
 
 # Prepare base distribution
 cd build


### PR DESCRIPTION
Buildbot makes built tarballs prior to triggering the packaging builds.  The debian packages build from the tarballs, rather than directly from source.  This pull request adds that capability to the opencast 4 spec.  This makes implementing the rpm builds in buildbot much much easier, without breaking the existing workflows for current users.